### PR TITLE
Fix demon slime item requirement typo

### DIFF
--- a/Monsters/DemonSlime.json
+++ b/Monsters/DemonSlime.json
@@ -7,7 +7,7 @@
   "encyclopedia": "These extremely rare monster girls are entirely made of dark purple goo, and subsist primarily on demonic energy for sustenance. They are far more intelligent than the average slime, so it is much more difficult to trick or deceive them.\n\nCare must be taken around them, because their favorite kind of food is sexual juices of any kind, and they have been known to wring out as much as they can from any humans they catch.\n\nIf conflict is unavoidable, use of pain or brute force is not advised, as their bodies make them all but immune to those types of attacks. When demonised, their only weakness is that of holy magic.",
   "tags": "none",
   "generic": "True",
-  "requires": ["Sigil of Allure"],
+  "requires": ["Sigil Of Allure"],
   "skillList": [
     "Gooey Caress",
     "Deep Kiss",


### PR DESCRIPTION
Fixes an issue with the item requirement in "DemonSlime.json" where the capitalisation of "Sigil Of Allure" was incorrect; "Sigil of Allure" is what was present. **OOPS**